### PR TITLE
Fix quick pick immediately disappearing

### DIFF
--- a/certificateManager.js
+++ b/certificateManager.js
@@ -40,7 +40,8 @@ var certificateManager = (function(){
 		// Notify msg
 		var selectTip = 'You can create, remove or active a profile.';
 		var options = {
-			placeHolder: selectTip
+			placeHolder: selectTip,
+			ignoreFocusOut: true
 		};
         logger.info(moduleName, selectTip);
 

--- a/createProject.js
+++ b/createProject.js
@@ -64,7 +64,8 @@ var FileController = (function () {
         // Notify msg
 		var selectTip = 'Please select a template:';
 		var options = {
-			placeHolder: selectTip
+			placeHolder: selectTip,
+			ignoreFocusOut: true
 		};
         logger.info(moduleName, selectTip);
 

--- a/setExceptionPath.js
+++ b/setExceptionPath.js
@@ -23,7 +23,8 @@ var setExceptionPath = (function() {
 		// Notify msg
 		var selectTip = 'You can add, delete Exception Path.';
 		var options = {
-			placeHolder: selectTip
+			placeHolder: selectTip,
+			ignoreFocusOut: true
 		};
         logger.info(moduleName, selectTip);
 


### PR DESCRIPTION
Fixes #18 and keeps the VSCode quick pick open.